### PR TITLE
Migration from nats to async-nats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,12 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
 pg_test = []
 
 [dependencies]
-nats = "0.25.0"
+async-nats = "0.38.0"
 parking_lot = "0.12.3"
 pgrx = "0.12.6"
 regex = "1.11.1"
 thiserror = "2.0.11"
+tokio = "1.43.0"
 
 [dev-dependencies]
 pgrx-tests = "0.12.6"

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,6 +1,6 @@
 use pgrx::prelude::*;
 
-use crate::{connection::NATS_CONNECTION, utils::do_panic_with_message};
+use crate::{ctx::CTX, utils::do_panic_with_message};
 
 #[pg_extern]
 fn get_config(config_name: &str) -> Option<String> {
@@ -27,7 +27,7 @@ fn set_config(config_name: &str, config_value: &str) {
   });
 
   if config_name.to_lowercase().contains("nats.") {
-    NATS_CONNECTION.invalidate();
+    CTX.rt().block_on(CTX.nats().invalidate());
   }
 }
 

--- a/src/api/nats.rs
+++ b/src/api/nats.rs
@@ -1,17 +1,19 @@
 use pgrx::pg_extern;
 
-use crate::{connection::NATS_CONNECTION, utils::format_message};
+use crate::{ctx::CTX, utils::format_message};
 
 #[pg_extern]
 fn nats_publish(publish_text: &str, subject: &str) -> Result<(), String> {
-  NATS_CONNECTION
-    .publish(publish_text, subject)
+  CTX
+    .rt()
+    .block_on(CTX.nats().publish(publish_text, subject))
     .map_err(|err| format_message(err.to_string()))
 }
 
 #[pg_extern]
 fn nats_publish_stream(publish_text: &str, subject: &str) -> Result<(), String> {
-  NATS_CONNECTION
-    .publish_stream(publish_text, subject)
+  CTX
+    .rt()
+    .block_on(CTX.nats().publish_stream(publish_text, subject))
     .map_err(|err| format_message(err.to_string()))
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -111,10 +111,10 @@ impl NatsConnection {
 
     let connection = async_nats::connect(format!("{0}:{1}", host, port))
       .await
-      .map_err(|err| PgNatsError::ConnectionError {
+      .map_err(|io_error| PgNatsError::Connection {
         host: host.to_string(),
         port: port as u16,
-        io_error: err.to_string(),
+        io_error,
       })?;
 
     let mut jetstream = async_nats::jetstream::new(connection.clone());

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,0 +1,26 @@
+use std::sync::LazyLock;
+
+use crate::connection::NatsConnection;
+
+pub static CTX: LazyLock<Context> = LazyLock::new(|| Context {
+  nats_connection: Default::default(),
+  rt: tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .expect("Failed to initialize Tokio runtime"),
+});
+
+pub struct Context {
+  nats_connection: NatsConnection,
+  rt: tokio::runtime::Runtime,
+}
+
+impl Context {
+  pub fn nats(&self) -> &NatsConnection {
+    &self.nats_connection
+  }
+
+  pub fn rt(&self) -> &tokio::runtime::Runtime {
+    &self.rt
+  }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,10 +8,10 @@ use thiserror::Error as TError;
 #[derive(TError, Debug)]
 pub enum PgNatsError {
   #[error("publish error {0}")]
-  PublishIoError(Error<PublishErrorKind>),
+  PublishIoError(#[from] Error<PublishErrorKind>),
 
   #[error("jetsteam publish error {0}")]
-  JetStreamPublishIoError(Error<jetstream::context::PublishErrorKind>),
+  JetStreamPublishIoError(#[from] Error<jetstream::context::PublishErrorKind>),
 
   #[error("failed to connect to nats server {host}:{port}. {io_error}")]
   ConnectionError {
@@ -21,41 +21,11 @@ pub enum PgNatsError {
   },
 
   #[error("update stream info {0}")]
-  UpdateStreamError(Error<jetstream::context::CreateStreamErrorKind>),
+  UpdateStreamError(#[from] Error<jetstream::context::CreateStreamErrorKind>),
 
   #[error("nats buffer flush error {0}")]
-  FlushError(Error<FlushErrorKind>),
+  FlushError(#[from] Error<FlushErrorKind>),
 
   #[error("failed to get stream info {0}")]
-  StreamInfoError(Error<jetstream::context::RequestErrorKind>),
-}
-
-impl From<Error<PublishErrorKind>> for PgNatsError {
-  fn from(value: Error<PublishErrorKind>) -> Self {
-    PgNatsError::PublishIoError(value)
-  }
-}
-
-impl From<Error<FlushErrorKind>> for PgNatsError {
-  fn from(value: Error<FlushErrorKind>) -> Self {
-    PgNatsError::FlushError(value)
-  }
-}
-
-impl From<Error<jetstream::context::PublishErrorKind>> for PgNatsError {
-  fn from(value: Error<jetstream::context::PublishErrorKind>) -> Self {
-    PgNatsError::JetStreamPublishIoError(value)
-  }
-}
-
-impl From<Error<jetstream::context::RequestErrorKind>> for PgNatsError {
-  fn from(value: Error<jetstream::context::RequestErrorKind>) -> Self {
-    PgNatsError::StreamInfoError(value)
-  }
-}
-
-impl From<Error<jetstream::context::CreateStreamErrorKind>> for PgNatsError {
-  fn from(value: Error<jetstream::context::CreateStreamErrorKind>) -> Self {
-    PgNatsError::UpdateStreamError(value)
-  }
+  StreamInfoError(#[from] Error<jetstream::context::RequestErrorKind>),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,16 +2,22 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PgNatsError {
-  #[error("publish error: {0}")]
-  PublishIo(std::io::Error),
+  #[error("publish error {0}")]
+  PublishIoError(String),
 
   #[error("failed to connect to nats server {host}:{port}. {io_error}")]
-  Connection {
+  ConnectionError {
     host: String,
     port: u16,
-    io_error: std::io::Error,
+    io_error: String,
   },
 
-  #[error("update stream info: {0}")]
-  UpdateStream(std::io::Error),
+  #[error("update stream info {0}")]
+  UpdateStreamError(String),
+
+  #[error("nats buffer flush error")]
+  FlushError,
+
+  #[error("failed to get stream info")]
+  StreamInfoError,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,17 @@
-use thiserror::Error;
+use async_nats::{
+  client::{FlushErrorKind, PublishErrorKind},
+  error::Error,
+  jetstream,
+};
+use thiserror::Error as TError;
 
-#[derive(Error, Debug)]
+#[derive(TError, Debug)]
 pub enum PgNatsError {
   #[error("publish error {0}")]
-  PublishIoError(String),
+  PublishIoError(Error<PublishErrorKind>),
+
+  #[error("jetsteam publish error {0}")]
+  JetStreamPublishIoError(Error<jetstream::context::PublishErrorKind>),
 
   #[error("failed to connect to nats server {host}:{port}. {io_error}")]
   ConnectionError {
@@ -13,11 +21,41 @@ pub enum PgNatsError {
   },
 
   #[error("update stream info {0}")]
-  UpdateStreamError(String),
+  UpdateStreamError(Error<jetstream::context::CreateStreamErrorKind>),
 
-  #[error("nats buffer flush error")]
-  FlushError,
+  #[error("nats buffer flush error {0}")]
+  FlushError(Error<FlushErrorKind>),
 
-  #[error("failed to get stream info")]
-  StreamInfoError,
+  #[error("failed to get stream info {0}")]
+  StreamInfoError(Error<jetstream::context::RequestErrorKind>),
+}
+
+impl From<Error<PublishErrorKind>> for PgNatsError {
+  fn from(value: Error<PublishErrorKind>) -> Self {
+    PgNatsError::PublishIoError(value)
+  }
+}
+
+impl From<Error<FlushErrorKind>> for PgNatsError {
+  fn from(value: Error<FlushErrorKind>) -> Self {
+    PgNatsError::FlushError(value)
+  }
+}
+
+impl From<Error<jetstream::context::PublishErrorKind>> for PgNatsError {
+  fn from(value: Error<jetstream::context::PublishErrorKind>) -> Self {
+    PgNatsError::JetStreamPublishIoError(value)
+  }
+}
+
+impl From<Error<jetstream::context::RequestErrorKind>> for PgNatsError {
+  fn from(value: Error<jetstream::context::RequestErrorKind>) -> Self {
+    PgNatsError::StreamInfoError(value)
+  }
+}
+
+impl From<Error<jetstream::context::CreateStreamErrorKind>> for PgNatsError {
+  fn from(value: Error<jetstream::context::CreateStreamErrorKind>) -> Self {
+    PgNatsError::UpdateStreamError(value)
+  }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,31 +1,31 @@
 use async_nats::{
   client::{FlushErrorKind, PublishErrorKind},
   error::Error,
-  jetstream,
+  jetstream, ConnectErrorKind,
 };
 use thiserror::Error as TError;
 
 #[derive(TError, Debug)]
 pub enum PgNatsError {
   #[error("publish error {0}")]
-  PublishIoError(#[from] Error<PublishErrorKind>),
+  PublishIo(#[from] Error<PublishErrorKind>),
 
   #[error("jetsteam publish error {0}")]
-  JetStreamPublishIoError(#[from] Error<jetstream::context::PublishErrorKind>),
+  JetStreamPublishIo(#[from] Error<jetstream::context::PublishErrorKind>),
 
   #[error("failed to connect to nats server {host}:{port}. {io_error}")]
-  ConnectionError {
+  Connection {
     host: String,
     port: u16,
-    io_error: String,
+    io_error: Error<ConnectErrorKind>,
   },
 
   #[error("update stream info {0}")]
-  UpdateStreamError(#[from] Error<jetstream::context::CreateStreamErrorKind>),
+  UpdateStream(#[from] Error<jetstream::context::CreateStreamErrorKind>),
 
   #[error("nats buffer flush error {0}")]
-  FlushError(#[from] Error<FlushErrorKind>),
+  Flush(#[from] Error<FlushErrorKind>),
 
   #[error("failed to get stream info {0}")]
-  StreamInfoError(#[from] Error<jetstream::context::RequestErrorKind>),
+  StreamInfo(#[from] Error<jetstream::context::RequestErrorKind>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod connection;
+mod ctx;
 mod errors;
 mod init;
 mod tests;


### PR DESCRIPTION
Now all `NatsConnection` methods are async, blocking occurs in the `pg_extern` function.

Created a global context that stores tokio runtime and `NatsConnection`.