### PR TITLE
Fix problems with NATS Client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
     services:
       nats:
         image: nats:latest
+        options: "-js"
         ports:
           - 4222:4222
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
+    services:
+      nats:
+        image: nats:latest
+        ports:
+          - 4222:4222
+
     steps:
       - uses: actions/checkout@v4
 
@@ -45,6 +51,9 @@ jobs:
           if [ ! -d "$HOME/.pgrx" ]; then
             cargo pgrx init
           fi
+
+      - name: Wait for NATS
+        run: timeout 60 sh -c 'until nc -z localhost 4222; do sleep 1; done'
 
       - name: Run pgrx tests
         run: cargo pgrx test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ path = "./src/bin/pgrx_embed.rs"
 
 [features]
 default = ["pg13"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
-pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
-pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
-pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
-pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
+pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 
 [dependencies]
@@ -27,9 +27,9 @@ parking_lot = "0.12.3"
 pgrx = "0.12.6"
 regex = "1.11.1"
 serde_json = "1.0.138"
-testcontainers = { version = "0.23.1", features = ["blocking"]}
+testcontainers = { version = "0.23.1", features = ["blocking"] }
 thiserror = "2.0.11"
-tokio = "1.43.0"
+tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread"] }
 
 [dev-dependencies]
 pgrx-tests = "0.12.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,12 @@ pg_test = []
 [dependencies]
 async-nats = "0.38.0"
 futures = "0.3.31"
-parking_lot = "0.12.3"
 pgrx = "0.12.6"
 regex = "1.11.1"
 serde_json = "1.0.138"
-testcontainers = { version = "0.23.1", features = ["blocking"] }
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread"] }
+testcontainers = { version = "0.23.1", features = ["blocking"] }
 
 [dev-dependencies]
 pgrx-tests = "0.12.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ regex = "1.11.1"
 serde_json = "1.0.138"
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread"] }
-testcontainers = { version = "0.23.1", features = ["blocking"] }
 
 [dev-dependencies]
 pgrx-tests = "0.12.6"
+testcontainers = { version = "0.23.1", features = ["blocking"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(pgrx_embed)'] }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ cargo install nats-connect
 -- Конфигурируем
 Set nats.host = '127.0.0.1';
 Set nats.port = 4222;
+Set nats.capacity = 128;
 
 -- Перезагружаем конфигурацию
 Select pgnats_reload_conf();
@@ -43,16 +44,16 @@ Select nats_put_jsonb('bucket', 'key', '{}'::jsonb);
 -- Функция сохраняет данные в формате Json в Key-Value (KV) хранилище NATS JetStream, используя указанный ключ
 Select nats_put_json('bucket', 'key', '{}'::json);
 
--- Извлекает бинарные данные по указанному ключу из указанного бакета 
+-- Извлекает бинарные данные по указанному ключу из указанного бакета
 Select nats_get_binary('bucket', 'key');
 
--- Извлекает текстовые данные по указанному ключу из указанного бакета 
+-- Извлекает текстовые данные по указанному ключу из указанного бакета
 Select nats_get_text('bucket', 'key');
 
--- Извлекает Binary Json по указанному ключу из указанного бакета 
+-- Извлекает Binary Json по указанному ключу из указанного бакета
 Select nats_get_jsonb('bucket', 'key');
 
--- Извлекает Json по указанному ключу из указанного бакета 
+-- Извлекает Json по указанному ключу из указанного бакета
 Select nats_get_json('bucket', 'key');
 
 -- Эта функция удаляет значение, связанное с указанным ключом, из указанного бакета
@@ -93,6 +94,7 @@ luxmsbi.cdc.audit.events: luxmsbi_cdc_audit
 
 - `nats.host` - Адрес сервера NATS. По-умолчанию `127.0.0.1`
 - `nats.port` - Порт, на котором работает сервер NATS. По-умолчанию `4222`
+- `nats.capacity` - Емкость очереди команд в NATS Client. По-умолчанию `128`
 
 ### connection.rs
 
@@ -100,7 +102,7 @@ luxmsbi.cdc.audit.events: luxmsbi_cdc_audit
 
 ### ctx.rs
 
-Глобальный контекст, в котором хранятся `NatsConnection` и `tokio-runtime`
+Глобальный контекст, в котором хранятся `NatsConnection`, `tokio-runtime`  и `LocalSet`
 
 ### errors.rs
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,7 @@ pub fn hello_pgnats() -> &'static str {
 
 #[pg_extern]
 pub fn pgnats_reload_conf() {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx.local_set.block_on(
       &ctx.rt,
       ctx.nats_connection.check_and_invalidate_connection(),
@@ -23,7 +23,7 @@ pub fn pgnats_reload_conf() {
 
 #[pg_extern]
 pub fn pgnats_reload_conf_force() {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,15 +14,18 @@ pub fn hello_pgnats() -> &'static str {
 #[pg_extern]
 pub fn pgnats_reload_conf() {
   CTX.with(|ctx| {
-    ctx
-      .rt()
-      .block_on(ctx.nats().check_and_invalidate_connection());
+    ctx.local_set.block_on(
+      &ctx.rt,
+      ctx.nats_connection.check_and_invalidate_connection(),
+    );
   });
 }
 
 #[pg_extern]
 pub fn pgnats_reload_conf_force() {
   CTX.with(|ctx| {
-    ctx.rt().block_on(ctx.nats().invalidate_connection());
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());
   });
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,14 +13,16 @@ pub fn hello_pgnats() -> &'static str {
 
 #[pg_extern]
 pub fn pgnats_reload_conf() {
-  CTX
-    .rt()
-    .block_on(CTX.nats().check_and_invalidate_connection());
+  CTX.with(|ctx| {
+    ctx
+      .rt()
+      .block_on(ctx.nats().check_and_invalidate_connection());
+  });
 }
 
 #[pg_extern]
 pub fn pgnats_reload_conf_force() {
-  CTX
-    .rt()
-    .block_on(CTX.nats().invalidate_connection());
+  CTX.with(|ctx| {
+    ctx.rt().block_on(ctx.nats().invalidate_connection());
+  });
 }

--- a/src/api/nats.rs
+++ b/src/api/nats.rs
@@ -4,48 +4,77 @@ use crate::{ctx::CTX, errors::PgNatsError};
 
 #[pg_extern]
 pub fn nats_publish(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().publish(subject, publish_text)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.publish(subject, publish_text))
+  })
 }
 
 #[pg_extern]
 pub fn nats_publish_stream(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
   CTX.with(|ctx| {
-    ctx
-      .rt()
-      .block_on(ctx.nats().publish_stream(subject, publish_text))
+    ctx.local_set.block_on(
+      &ctx.rt,
+      ctx.nats_connection.publish_stream(subject, publish_text),
+    )
   })
 }
 
 #[pg_extern]
 pub fn nats_put_binary(bucket: String, key: &str, data: &[u8]) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
+  })
 }
 
 #[pg_extern]
 pub fn nats_put_text(bucket: String, key: &str, data: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
+  })
 }
 
 #[pg_extern]
 pub fn nats_put_jsonb(bucket: String, key: &str, data: pgrx::JsonB) -> Result<(), PgNatsError> {
   let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
+  })
 }
 
 #[pg_extern]
 pub fn nats_put_json(bucket: String, key: &str, data: pgrx::Json) -> Result<(), PgNatsError> {
   let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
+  })
 }
 
 #[pg_extern]
 pub fn nats_get_binary(bucket: String, key: &str) -> Result<Option<Vec<u8>>, PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().get_value(bucket, key)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
+  })
 }
 
 #[pg_extern]
 pub fn nats_get_text(bucket: String, key: &str) -> Result<Option<String>, PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().get_value(bucket, key)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
+  })
 }
 
 #[pg_extern]
@@ -53,8 +82,8 @@ pub fn nats_get_json(bucket: String, key: &str) -> Result<Option<pgrx::Json>, Pg
   CTX
     .with(|ctx| {
       ctx
-        .rt()
-        .block_on(ctx.nats().get_value::<serde_json::Value>(bucket, key))
+        .local_set
+        .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
     })
     .map(|v| v.map(pgrx::Json))
 }
@@ -64,13 +93,17 @@ pub fn nats_get_jsonb(bucket: String, key: &str) -> Result<Option<pgrx::JsonB>, 
   CTX
     .with(|ctx| {
       ctx
-        .rt()
-        .block_on(ctx.nats().get_value::<serde_json::Value>(bucket, key))
+        .local_set
+        .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
     })
     .map(|v| v.map(pgrx::JsonB))
 }
 
 #[pg_extern]
 pub fn nats_delete_value(bucket: String, key: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().delete_value(bucket, key)))
+  CTX.with(|ctx| {
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.delete_value(bucket, key))
+  })
 }

--- a/src/api/nats.rs
+++ b/src/api/nats.rs
@@ -4,7 +4,7 @@ use crate::{ctx::CTX, errors::PgNatsError};
 
 #[pg_extern]
 pub fn nats_publish(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.publish(subject, publish_text))
@@ -13,7 +13,7 @@ pub fn nats_publish(subject: &str, publish_text: &str) -> Result<(), PgNatsError
 
 #[pg_extern]
 pub fn nats_publish_stream(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx.local_set.block_on(
       &ctx.rt,
       ctx.nats_connection.publish_stream(subject, publish_text),
@@ -23,7 +23,7 @@ pub fn nats_publish_stream(subject: &str, publish_text: &str) -> Result<(), PgNa
 
 #[pg_extern]
 pub fn nats_put_binary(bucket: String, key: &str, data: &[u8]) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
@@ -32,7 +32,7 @@ pub fn nats_put_binary(bucket: String, key: &str, data: &[u8]) -> Result<(), PgN
 
 #[pg_extern]
 pub fn nats_put_text(bucket: String, key: &str, data: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
@@ -42,7 +42,7 @@ pub fn nats_put_text(bucket: String, key: &str, data: &str) -> Result<(), PgNats
 #[pg_extern]
 pub fn nats_put_jsonb(bucket: String, key: &str, data: pgrx::JsonB) -> Result<(), PgNatsError> {
   let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
@@ -52,7 +52,7 @@ pub fn nats_put_jsonb(bucket: String, key: &str, data: pgrx::JsonB) -> Result<()
 #[pg_extern]
 pub fn nats_put_json(bucket: String, key: &str, data: pgrx::Json) -> Result<(), PgNatsError> {
   let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.put_value(bucket, key, data))
@@ -61,7 +61,7 @@ pub fn nats_put_json(bucket: String, key: &str, data: pgrx::Json) -> Result<(), 
 
 #[pg_extern]
 pub fn nats_get_binary(bucket: String, key: &str) -> Result<Option<Vec<u8>>, PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
@@ -70,7 +70,7 @@ pub fn nats_get_binary(bucket: String, key: &str) -> Result<Option<Vec<u8>>, PgN
 
 #[pg_extern]
 pub fn nats_get_text(bucket: String, key: &str) -> Result<Option<String>, PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
@@ -80,7 +80,7 @@ pub fn nats_get_text(bucket: String, key: &str) -> Result<Option<String>, PgNats
 #[pg_extern]
 pub fn nats_get_json(bucket: String, key: &str) -> Result<Option<pgrx::Json>, PgNatsError> {
   CTX
-    .with(|ctx| {
+    .with_borrow_mut(|ctx| {
       ctx
         .local_set
         .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
@@ -91,7 +91,7 @@ pub fn nats_get_json(bucket: String, key: &str) -> Result<Option<pgrx::Json>, Pg
 #[pg_extern]
 pub fn nats_get_jsonb(bucket: String, key: &str) -> Result<Option<pgrx::JsonB>, PgNatsError> {
   CTX
-    .with(|ctx| {
+    .with_borrow_mut(|ctx| {
       ctx
         .local_set
         .block_on(&ctx.rt, ctx.nats_connection.get_value(bucket, key))
@@ -101,7 +101,7 @@ pub fn nats_get_jsonb(bucket: String, key: &str) -> Result<Option<pgrx::JsonB>, 
 
 #[pg_extern]
 pub fn nats_delete_value(bucket: String, key: &str) -> Result<(), PgNatsError> {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.delete_value(bucket, key))

--- a/src/api/nats.rs
+++ b/src/api/nats.rs
@@ -4,71 +4,73 @@ use crate::{ctx::CTX, errors::PgNatsError};
 
 #[pg_extern]
 pub fn nats_publish(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(CTX.nats().publish(subject, publish_text))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().publish(subject, publish_text)))
 }
 
 #[pg_extern]
 pub fn nats_publish_stream(subject: &str, publish_text: &str) -> Result<(), PgNatsError> {
-  CTX
-    .rt()
-    .block_on(CTX.nats().publish_stream(subject, publish_text))
+  CTX.with(|ctx| {
+    ctx
+      .rt()
+      .block_on(ctx.nats().publish_stream(subject, publish_text))
+  })
 }
 
 #[pg_extern]
 pub fn nats_put_binary(bucket: String, key: &str, data: &[u8]) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(CTX.nats().put_value(bucket, key, data))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
 }
 
 #[pg_extern]
 pub fn nats_put_text(bucket: String, key: &str, data: &str) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(CTX.nats().put_value(bucket, key, data))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
 }
 
 #[pg_extern]
 pub fn nats_put_jsonb(bucket: String, key: &str, data: pgrx::JsonB) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(async {
-    let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-
-    CTX.nats().put_value(bucket, key, data).await
-  })
+  let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
 }
 
 #[pg_extern]
 pub fn nats_put_json(bucket: String, key: &str, data: pgrx::Json) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(async {
-    let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
-
-    CTX.nats().put_value(bucket, key, data).await
-  })
+  let data = serde_json::to_string(&data.0).map_err(PgNatsError::Serialize)?;
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().put_value(bucket, key, data)))
 }
 
 #[pg_extern]
 pub fn nats_get_binary(bucket: String, key: &str) -> Result<Option<Vec<u8>>, PgNatsError> {
-  CTX.rt().block_on(CTX.nats().get_value(bucket, key))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().get_value(bucket, key)))
 }
 
 #[pg_extern]
 pub fn nats_get_text(bucket: String, key: &str) -> Result<Option<String>, PgNatsError> {
-  CTX.rt().block_on(CTX.nats().get_value(bucket, key))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().get_value(bucket, key)))
 }
 
 #[pg_extern]
 pub fn nats_get_json(bucket: String, key: &str) -> Result<Option<pgrx::Json>, PgNatsError> {
   CTX
-    .rt()
-    .block_on(CTX.nats().get_value::<serde_json::Value>(bucket, key))
+    .with(|ctx| {
+      ctx
+        .rt()
+        .block_on(ctx.nats().get_value::<serde_json::Value>(bucket, key))
+    })
     .map(|v| v.map(pgrx::Json))
 }
 
 #[pg_extern]
 pub fn nats_get_jsonb(bucket: String, key: &str) -> Result<Option<pgrx::JsonB>, PgNatsError> {
   CTX
-    .rt()
-    .block_on(CTX.nats().get_value::<serde_json::Value>(bucket, key))
+    .with(|ctx| {
+      ctx
+        .rt()
+        .block_on(ctx.nats().get_value::<serde_json::Value>(bucket, key))
+    })
     .map(|v| v.map(pgrx::JsonB))
 }
 
 #[pg_extern]
 pub fn nats_delete_value(bucket: String, key: &str) -> Result<(), PgNatsError> {
-  CTX.rt().block_on(CTX.nats().delete_value(bucket, key))
+  CTX.with(|ctx| ctx.rt().block_on(ctx.nats().delete_value(bucket, key)))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,18 +9,20 @@ use crate::utils::format_message;
 // configs names
 pub const CONFIG_HOST: &str = "nats.host";
 pub const CONFIG_PORT: &str = "nats.port";
+pub const CONFIG_CAPACITY: &str = "nats.capacity";
 
 // configs values
 pub static GUC_HOST: GucSetting<Option<&'static CStr>> =
   GucSetting::<Option<&'static CStr>>::new(Some(c"127.0.0.1"));
 pub static GUC_PORT: GucSetting<i32> = GucSetting::<i32>::new(4222);
+pub static GUC_CAPACITY: GucSetting<i32> = GucSetting::<i32>::new(128);
 
 pub fn initialize_configuration() {
   // initialization of postgres userdef configs
   GucRegistry::define_string_guc(
     CONFIG_HOST,
-    "address of rust service",
-    "address of rust service",
+    "address of NATS Server",
+    "address of NATS Server",
     &GUC_HOST,
     GucContext::Userset,
     GucFlags::default(),
@@ -28,10 +30,21 @@ pub fn initialize_configuration() {
 
   GucRegistry::define_int_guc(
     CONFIG_PORT,
-    "port of rust service",
-    "port of rust service",
+    "port of NATS Server",
+    "port of NATS Server",
     &GUC_PORT,
     1024,
+    0xFFFF,
+    GucContext::Userset,
+    GucFlags::default(),
+  );
+
+  GucRegistry::define_int_guc(
+    CONFIG_CAPACITY,
+    "Buffer capacity of NATS Client",
+    "Buffer capacity of NATS Client",
+    &GUC_CAPACITY,
+    1,
     0xFFFF,
     GucContext::Userset,
     GucFlags::default(),
@@ -40,7 +53,7 @@ pub fn initialize_configuration() {
   ereport!(
     PgLogLevel::INFO,
     PgSqlErrorCode::ERRCODE_SUCCESSFUL_COMPLETION,
-    format_message("initialize_configuration success!")
+    format_message("PGNats has been successfully initialized!")
   );
 }
 
@@ -51,5 +64,6 @@ pub fn fetch_connection_options() -> ConnectionOptions {
       .map(|host| host.to_string_lossy().to_string())
       .unwrap_or_default(),
     port: GUC_PORT.get() as u16,
+    capacity: GUC_CAPACITY.get() as usize,
   }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,22 +1,20 @@
 use async_nats::jetstream::kv::Store;
 use async_nats::jetstream::Context;
 use async_nats::Client;
-use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use pgrx::prelude::*;
 
 use crate::config::fetch_connection_options;
 use crate::errors::PgNatsError;
-use crate::utils::{format_message, get_stream_name_by_subject, FromBytes};
+use crate::utils::{format_message, FromBytes};
 
 #[derive(Default)]
 pub struct NatsConnection {
-  connection: RwLock<Option<Arc<Client>>>,
-  jetstream: RwLock<Option<Arc<Context>>>,
-  cached_buckets: RwLock<HashMap<String, Arc<Store>>>,
-  current_config: RwLock<Option<ConnectionOptions>>,
+  connection: Option<Client>,
+  jetstream: Option<Context>,
+  cached_buckets: HashMap<String, Store>,
+  current_config: Option<ConnectionOptions>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -27,29 +25,15 @@ pub struct ConnectionOptions {
 
 impl NatsConnection {
   pub async fn publish(
-    self: &Arc<Self>,
-    subject: impl ToString,
-    message: impl Into<Vec<u8>>,
-  ) -> Result<(), PgNatsError> {
-    let subject = subject.to_string();
-    let message: Vec<u8> = message.into();
-    let connection = self.get_connection().await?;
-
-    connection.publish(subject, message.into()).await?;
-
-    Ok(())
-  }
-
-  pub async fn publish_stream(
-    self: &Arc<Self>,
+    &mut self,
     subject: impl ToString,
     message: impl Into<Vec<u8>>,
   ) -> Result<(), PgNatsError> {
     let subject = subject.to_string();
     let message: Vec<u8> = message.into();
 
-    let _ask = self
-      .touch_stream_subject(subject.clone())
+    self
+      .get_connection()
       .await?
       .publish(subject, message.into())
       .await?;
@@ -57,13 +41,30 @@ impl NatsConnection {
     Ok(())
   }
 
-  pub async fn invalidate_connection(&self) {
-    let connection = { self.connection.write().take() };
+  pub async fn publish_stream(
+    &mut self,
+    subject: impl ToString,
+    message: impl Into<Vec<u8>>,
+  ) -> Result<(), PgNatsError> {
+    let subject = subject.to_string();
+    let message: Vec<u8> = message.into();
+
+    let _ask = self
+      .get_jetstream()
+      .await?
+      .publish(subject, message.into())
+      .await?;
+
+    Ok(())
+  }
+
+  pub async fn invalidate_connection(&mut self) {
+    let connection = { self.connection.take() };
 
     {
-      self.cached_buckets.write().clear();
-      let _ = self.jetstream.write().take();
-      let _ = self.current_config.write().take();
+      self.cached_buckets.clear();
+      let _ = self.jetstream.take();
+      let _ = self.current_config.take();
     }
 
     if let Some(conn) = connection {
@@ -83,9 +84,9 @@ impl NatsConnection {
     }
   }
 
-  pub async fn check_and_invalidate_connection(&self) {
+  pub async fn check_and_invalidate_connection(&mut self) {
     let (changed, new_config) = {
-      let config = self.current_config.read();
+      let config = &self.current_config;
       let fetched_config = fetch_connection_options();
 
       let changed = config.as_ref() != Some(&fetched_config);
@@ -96,13 +97,12 @@ impl NatsConnection {
     if changed {
       self.invalidate_connection().await;
 
-      let mut config = self.current_config.write();
-      *config = Some(new_config);
+      self.current_config = Some(new_config);
     }
   }
 
   pub async fn put_value(
-    self: &Arc<Self>,
+    &mut self,
     bucket: impl ToString,
     key: impl AsRef<str>,
     data: impl Into<Vec<u8>>,
@@ -116,7 +116,7 @@ impl NatsConnection {
   }
 
   pub async fn get_value<T: FromBytes>(
-    self: &Arc<Self>,
+    &mut self,
     bucket: impl ToString,
     key: impl Into<String>,
   ) -> Result<Option<T>, PgNatsError> {
@@ -131,7 +131,7 @@ impl NatsConnection {
   }
 
   pub async fn delete_value(
-    self: &Arc<Self>,
+    &mut self,
     bucket: impl ToString,
     key: impl AsRef<str>,
   ) -> Result<(), PgNatsError> {
@@ -142,61 +142,60 @@ impl NatsConnection {
     Ok(())
   }
 
-  async fn get_connection(self: &Arc<Self>) -> Result<Arc<Client>, PgNatsError> {
-    if let Some(client) = &*self.connection.read() {
-      return Ok(Arc::clone(client));
+  async fn get_connection(&mut self) -> Result<&Client, PgNatsError> {
+    if self.connection.is_none() {
+      self.initialize_connection().await?;
     }
 
-    let (connection, _) = self.initialize_connection().await?;
-
-    Ok(connection)
+    Ok(
+      self
+        .connection
+        .as_ref()
+        .expect("unreachable, must be initialized"),
+    )
   }
 
-  async fn get_jetstream(self: &Arc<Self>) -> Result<Arc<Context>, PgNatsError> {
-    if let Some(jetstream) = &*self.jetstream.read() {
-      return Ok(Arc::clone(jetstream));
+  async fn get_jetstream(&mut self) -> Result<&Context, PgNatsError> {
+    if self.connection.is_none() {
+      self.initialize_connection().await?;
     }
 
-    let (_, jetstream) = self.initialize_connection().await?;
-
-    Ok(jetstream)
+    Ok(
+      self
+        .jetstream
+        .as_ref()
+        .expect("unreachable, must be initialized"),
+    )
   }
 
-  async fn get_or_create_bucket(
-    self: &Arc<Self>,
-    bucket: impl ToString,
-  ) -> Result<Arc<Store>, PgNatsError> {
+  async fn get_or_create_bucket(&mut self, bucket: impl ToString) -> Result<&Store, PgNatsError> {
     let bucket = bucket.to_string();
 
-    {
-      let cached = self.cached_buckets.read();
-      if let Some(store) = cached.get(&bucket) {
-        return Ok(Arc::clone(store));
-      }
+    if !self.cached_buckets.contains_key(&bucket) {
+      let new_store = {
+        let jetstream = self.get_jetstream().await?;
+        jetstream
+          .create_key_value(async_nats::jetstream::kv::Config {
+            bucket: bucket.clone(),
+            ..Default::default()
+          })
+          .await?
+      };
+
+      let _ = self.cached_buckets.insert(bucket.clone(), new_store);
     }
 
-    let jetstream = self.get_jetstream().await?;
-    let new_store = Arc::new(
-      jetstream
-        .create_key_value(async_nats::jetstream::kv::Config {
-          bucket: bucket.clone(),
-          ..Default::default()
-        })
-        .await?,
-    );
-
-    let mut cached = self.cached_buckets.write();
-    let _ = cached.insert(bucket, Arc::clone(&new_store));
-
-    Ok(new_store)
+    Ok(
+      self
+        .cached_buckets
+        .get(&bucket)
+        .expect("unreachable, must be initialized"),
+    )
   }
 
-  async fn initialize_connection(
-    self: &Arc<Self>,
-  ) -> Result<(Arc<Client>, Arc<Context>), PgNatsError> {
+  async fn initialize_connection(&mut self) -> Result<(), PgNatsError> {
     let config = self
       .current_config
-      .write()
       .get_or_insert_with(fetch_connection_options)
       .clone();
 
@@ -212,26 +211,20 @@ impl NatsConnection {
     let mut jetstream = async_nats::jetstream::new(connection.clone());
     jetstream.set_timeout(std::time::Duration::from_secs(5));
 
-    let mut nats_connection = self.connection.write();
-    let mut nats_jetstream = self.jetstream.write();
+    self.connection = Some(connection);
+    self.jetstream = Some(jetstream);
 
-    let connection = Arc::new(connection);
-    let jetstream = Arc::new(jetstream);
-    *nats_connection = Some(Arc::clone(&connection));
-    *nats_jetstream = Some(Arc::clone(&jetstream));
-
-    Ok((connection, jetstream))
+    Ok(())
   }
 
-  /// Touch stream by subject
-  /// if stream for subject not exists, creat it
-  /// if stream for subject exists, but not contains current subject, add subject to config
+  #[allow(unused, deprecated)]
+  #[deprecated]
   async fn touch_stream_subject(
-    self: &Arc<Self>,
+    &mut self,
     subject: impl ToString,
-  ) -> Result<Arc<Context>, PgNatsError> {
+  ) -> Result<&Context, PgNatsError> {
     let subject = subject.to_string();
-    let stream_name = get_stream_name_by_subject(&subject);
+    let stream_name = crate::utils::get_stream_name_by_subject(&subject);
 
     let jetstream = self.get_jetstream().await?;
     let info = jetstream.get_stream(&stream_name).await;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -21,6 +21,7 @@ pub struct NatsConnection {
 pub struct ConnectionOptions {
   pub host: String,
   pub port: u16,
+  pub capacity: usize,
 }
 
 impl NatsConnection {
@@ -196,10 +197,10 @@ impl NatsConnection {
   async fn initialize_connection(&mut self) -> Result<(), PgNatsError> {
     let config = self
       .current_config
-      .get_or_insert_with(fetch_connection_options)
-      .clone();
+      .get_or_insert_with(fetch_connection_options);
 
     let connection = async_nats::ConnectOptions::new()
+      .client_capacity(config.capacity)
       .connect(format!("{0}:{1}", config.host, config.port))
       .await
       .map_err(|io_error| PgNatsError::Connection {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,9 +1,9 @@
-use std::{cell::LazyCell, sync::Arc};
+use std::cell::RefCell;
 
 use crate::connection::NatsConnection;
 
 thread_local! {
-    pub static CTX: LazyCell<Context> = LazyCell::new(|| Context {
+    pub static CTX: RefCell<Context> = RefCell::new(Context {
         nats_connection: Default::default(),
         rt: tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -14,7 +14,7 @@ thread_local! {
 }
 
 pub struct Context {
-  pub nats_connection: Arc<NatsConnection>,
+  pub nats_connection: NatsConnection,
   pub rt: tokio::runtime::Runtime,
   pub local_set: tokio::task::LocalSet,
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,14 +1,16 @@
-use std::sync::{Arc, LazyLock};
+use std::{cell::LazyCell, sync::Arc};
 
 use crate::connection::NatsConnection;
 
-pub static CTX: LazyLock<Context> = LazyLock::new(|| Context {
-  nats_connection: Default::default(),
-  rt: tokio::runtime::Builder::new_current_thread()
-    .enable_all()
-    .build()
-    .expect("Failed to initialize Tokio runtime"),
-});
+thread_local! {
+    pub static CTX: LazyCell<Context> = LazyCell::new(|| Context {
+        nats_connection: Default::default(),
+        rt: tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to initialize Tokio runtime"),
+    })
+}
 
 pub struct Context {
   nats_connection: Arc<NatsConnection>,

--- a/src/init.rs
+++ b/src/init.rs
@@ -13,12 +13,16 @@ pub extern "C" fn _PG_init() {
 #[pg_guard]
 pub extern "C" fn _PG_fini() {
   CTX.with(|ctx| {
-    ctx.rt().block_on(ctx.nats().invalidate_connection());
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());
   });
 }
 
 unsafe extern "C" fn extension_exit_callback(_: i32, _: pg_sys::Datum) {
   CTX.with(|ctx| {
-    ctx.rt().block_on(ctx.nats().invalidate_connection());
+    ctx
+      .local_set
+      .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());
   });
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -12,7 +12,7 @@ pub extern "C" fn _PG_init() {
 
 #[pg_guard]
 pub extern "C" fn _PG_fini() {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());
@@ -20,7 +20,7 @@ pub extern "C" fn _PG_fini() {
 }
 
 unsafe extern "C" fn extension_exit_callback(_: i32, _: pg_sys::Datum) {
-  CTX.with(|ctx| {
+  CTX.with_borrow_mut(|ctx| {
     ctx
       .local_set
       .block_on(&ctx.rt, ctx.nats_connection.invalidate_connection());

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,15 +6,19 @@ pub extern "C" fn _PG_init() {
   initialize_configuration();
 
   unsafe {
-    pg_sys::before_shmem_exit(Some(extension_exit_callback), pg_sys::Datum::from(0));
+    pg_sys::on_proc_exit(Some(extension_exit_callback), pg_sys::Datum::from(0));
   }
 }
 
 #[pg_guard]
 pub extern "C" fn _PG_fini() {
-  CTX.rt().block_on(CTX.nats().invalidate_connection());
+  CTX.with(|ctx| {
+    ctx.rt().block_on(ctx.nats().invalidate_connection());
+  });
 }
 
 unsafe extern "C" fn extension_exit_callback(_: i32, _: pg_sys::Datum) {
-  CTX.rt().block_on(CTX.nats().invalidate_connection());
+  CTX.with(|ctx| {
+    ctx.rt().block_on(ctx.nats().invalidate_connection());
+  });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,49 +4,27 @@
 #[pgrx::prelude::pg_schema]
 mod tests {
   use pgrx::{prelude::*, Json, JsonB};
-  use testcontainers::{
-    core::{ContainerPort, WaitFor},
-    runners::SyncRunner,
-    Container, GenericImage, ImageExt,
-  };
 
   use crate::api;
 
   const NATS_HOST: &str = "127.0.0.1";
+  const NATS_PORT: u16 = 4222;
 
   const NATS_HOST_CONF: &str = "nats.host";
   const NATS_PORT_CONF: &str = "nats.port";
 
-  #[must_use]
-  fn setup() -> (Container<GenericImage>, u16) {
-    let container = testcontainers::GenericImage::new("nats", "latest")
-      .with_exposed_port(ContainerPort::Tcp(4222))
-      .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
-      .with_cmd(["-js"])
-      .start()
-      .expect("Failed to start NATS server");
-
-    let host_port = container
-      .get_host_port_ipv4(ContainerPort::Tcp(4222))
-      .expect("Failed to get host port");
-
-    (container, host_port)
-  }
-
   #[pg_test]
   fn test_hello_pgnats() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     assert_eq!("Hello, pgnats!", api::hello_pgnats());
   }
 
   #[pg_test]
   fn test_nats_publish() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let subject = "test.test_nats_publish";
     let message = "Hello, World! 🦀";
@@ -57,9 +35,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_publish_stream() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let subject = "test.test_nats_publish_stream";
     let message = "Hello, World! 🦀";
@@ -70,9 +47,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_put_and_get_binary() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let bucket = "test_default".to_string();
     let key = "binary_key";
@@ -98,9 +74,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_put_and_get_text() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let bucket = "test_default".to_string();
     let key = "text_key";
@@ -118,9 +93,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_put_and_get_json() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let bucket = "test_default".to_string();
     let key = "json_key";
@@ -139,9 +113,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_put_and_get_jsonb() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let bucket = "test_default".to_string();
     let key = "jsonb_key";
@@ -168,9 +141,8 @@ mod tests {
 
   #[pg_test]
   fn test_nats_delete_value() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let bucket = "test_default".to_string();
     let key = "delete_key";
@@ -195,9 +167,8 @@ mod tests {
 
   #[pg_test]
   fn test_pgnats_reload_conf() {
-    let (_container, host_port) = setup();
     Spi::run(&format!("SET {NATS_HOST_CONF} = '{NATS_HOST}'")).expect("Failed to set NATS host");
-    Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
+    Spi::run(&format!("SET {NATS_PORT_CONF} = {NATS_PORT}")).expect("Failed to set NATS host");
 
     let res = api::nats_publish("test.test_pgnats_reload_conf", "test");
     assert!(res.is_ok(), "nats_publish occurs error: {:?}", res);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,28 +200,16 @@ mod tests {
     Spi::run(&format!("SET {NATS_PORT_CONF} = {}", host_port)).expect("Failed to set NATS host");
 
     let res = api::nats_publish("test.test_pgnats_reload_conf", "test");
-    assert!(
-      res.is_ok(),
-      "nats_publish occurs error: {:?}",
-      res
-    );
+    assert!(res.is_ok(), "nats_publish occurs error: {:?}", res);
 
     api::pgnats_reload_conf();
 
     let res = api::nats_publish("test.test_pgnats_reload_conf", "test");
-    assert!(
-      res.is_ok(),
-      "nats_publish occurs error: {:?}",
-      res
-    );
+    assert!(res.is_ok(), "nats_publish occurs error: {:?}", res);
 
     Spi::run(&format!("SET {NATS_HOST_CONF} = 'localhost1'")).expect("Failed to set NATS host");
     let res = api::nats_publish("test.test_pgnats_reload_conf", "test");
-    assert!(
-      res.is_ok(),
-      "nats_publish occurs error: {:?}",
-      res
-    );
+    assert!(res.is_ok(), "nats_publish occurs error: {:?}", res);
 
     api::pgnats_reload_conf();
 
@@ -231,12 +219,6 @@ mod tests {
     api::pgnats_reload_conf_force();
 
     let res = api::nats_publish("test.test_pgnats_reload_conf", "test");
-    assert!(
-      res.is_ok(),
-      "nats_publish occurs error: {:?}",
-      res
-    );
+    assert!(res.is_ok(), "nats_publish occurs error: {:?}", res);
   }
 }
-
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,9 +3,11 @@ use std::sync::LazyLock;
 
 use crate::errors::PgNatsError;
 
+#[deprecated]
 static REGEX_STREAM_NAME_LAST_PART: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"\.[^.]*$").expect("Wrong regex"));
 
+#[deprecated]
 static REGEX_SPECIAL_SYM: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"[.^?>*]").expect("Wrong regex"));
 
@@ -15,6 +17,8 @@ pub fn format_message(message_text: impl AsRef<str>) -> String {
   format!("{MSG_PREFIX}: {}", message_text.as_ref())
 }
 
+#[allow(deprecated)]
+#[deprecated]
 pub fn get_stream_name_by_subject(subject: &str) -> String {
   REGEX_SPECIAL_SYM
     .replace_all(

--- a/tests/pgnats_tests.rs
+++ b/tests/pgnats_tests.rs
@@ -1,0 +1,21 @@
+use testcontainers::{
+  core::{ContainerPort, WaitFor},
+  runners::SyncRunner,
+  Container, GenericImage, ImageExt,
+};
+
+#[must_use]
+fn _setup() -> (Container<GenericImage>, u16) {
+  let container = testcontainers::GenericImage::new("nats", "latest")
+    .with_exposed_port(ContainerPort::Tcp(4222))
+    .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+    .with_cmd(["-js"])
+    .start()
+    .expect("Failed to start NATS server");
+
+  let host_port = container
+    .get_host_port_ipv4(ContainerPort::Tcp(4222))
+    .expect("Failed to get host port");
+
+  (container, host_port)
+}


### PR DESCRIPTION
Closes #11
Closes #13 

- Tokio Runtime is muli-thread now
- All API functions call `NatsConnection` methods in `LocalSet`
- Removed crate `parking_lot`, removed using `Arc` and `Mutex` from NatsConnection
- Added buffer capacity configuration for NATS Client